### PR TITLE
功能：增加 iOS 27 中国大陆/国际混合地图支持

### DIFF
--- a/arguments-builder.config.ts
+++ b/arguments-builder.config.ts
@@ -29,6 +29,48 @@ export default defineConfig({
 	},
 	args: [
 		{
+			defaultValue: false,
+			description: "为 iOS 27 启用中国二维数据与 Apple 国际卫星、3D、Flyover 和 Look Around 的选择性合并。",
+			key: "Hybrid.Enabled",
+			name: "[iOS 27] 中国/国际混合地图",
+			type: "boolean",
+		},
+		{
+			defaultValue: "EXTENDED",
+			description: "选择注入到国际清单中的中国大陆二维图层范围。",
+			key: "Hybrid.MainlandLayers",
+			name: "[iOS 27] 中国二维图层",
+			options: [
+				{ key: "EXTENDED", label: "完整道路、建筑、POI、标签和交通" },
+				{ key: "CORE", label: "核心标准地图、建筑和 POI" },
+			],
+			type: "string",
+		},
+		{
+			defaultValue: "DISABLED",
+			description: "ROUTE 保留单一国际卫星选择器，并由客户端脚本按瓦片坐标选择 CN 端点。",
+			key: "Hybrid.Mainland3D",
+			name: "[iOS 27] 中国卫星/3D 处理",
+			options: [
+				{ key: "DISABLED", label: "关闭中国 3D 路由" },
+				{ key: "ROUTE", label: "按瓦片坐标路由（推荐给支持请求脚本的客户端）" },
+				{ key: "NATIVE", label: "并存中国原生 3D selector（实验）" },
+			],
+			type: "string",
+		},
+		{
+			defaultValue: "CN_POI",
+			description: "控制中国地点、反向地理编码、导航和交通服务的恢复范围。",
+			key: "Hybrid.ServiceMode",
+			name: "[iOS 27] 中国服务范围",
+			options: [
+				{ key: "CN_POI", label: "中国 POI/搜索，导航保留 Apple" },
+				{ key: "APPLE", label: "Apple 国际前台服务" },
+				{ key: "CN_FULL", label: "中国 POI、导航与交通" },
+			],
+			type: "string",
+		},
+		{
 			defaultValue: "CN",
 			description: "此选项影响“地图”整体配置内容，包括以下的地图功能与服务。",
 			key: "GeoManifest.Dynamic.Config.CountryCode",

--- a/rspack.config.mjs
+++ b/rspack.config.mjs
@@ -7,6 +7,7 @@ export default defineConfig({
 	entry: {
 		request: "./src/request.js",
 		response: "./src/response.js",
+		"satellite-route": "./src/satellite-route.js",
 	},
 	output: {
 		chunkFormat: false,

--- a/scripts/test-selective-hybrid-route-v6.mjs
+++ b/scripts/test-selective-hybrid-route-v6.mjs
@@ -1,0 +1,28 @@
+import { readFile } from "node:fs/promises";
+import vm from "node:vm";
+
+const script = await readFile(process.argv[2] ?? "dist/satellite-route.bundle.js", "utf8");
+
+const run = url => {
+	let result;
+	vm.runInNewContext(script, {
+		URL,
+		Number,
+		$request: { url },
+		$done: value => { result = value; },
+	});
+	return result?.url ?? url;
+};
+
+const china = new URL(run("https://gspe11-ssl.ls.apple.com/tile?style=98&v=226&region=0&z=14&x=12927&y=6735&h=0&preflight=2&accessKey=test"));
+if (china.hostname !== "gspe11-2-cn-ssl.ls.apple.com" || china.pathname !== "/2/tiles") throw new Error(`CN endpoint mismatch: ${china}`);
+for (const [key, value] of Object.entries({ style: "7", v: "68", size: "1", scale: "2", vertical_datum: "wgs84", z: "14", x: "12927", y: "6735", preflight: "2", accessKey: "test" })) {
+	if (china.searchParams.get(key) !== value) throw new Error(`CN ${key} mismatch: ${china}`);
+}
+if (china.searchParams.has("region") || china.searchParams.has("h")) throw new Error(`CN obsolete parameters retained: ${china}`);
+
+const tokyoInput = "https://gspe11-ssl.ls.apple.com/tile?style=98&v=226&region=0&z=17&x=116423&y=51615&h=0&preflight=2&accessKey=test";
+const tokyo = run(tokyoInput);
+if (tokyo !== tokyoInput) throw new Error(`Tokyo request was changed: ${tokyo}`);
+
+console.log("v6 route diagnostic tests passed");

--- a/src/class/GEOResourceManifestDownload.mjs
+++ b/src/class/GEOResourceManifestDownload.mjs
@@ -11,53 +11,53 @@ export default class GEOResourceManifestDownload {
 		//Console.debug(`body.tileSet: ${JSON.stringify(body.tileSet)}`);
 		if (typeof body.tileSet !== "undefined")
 			body.tileSet = body.tileSet.map(tile => {
-				if (typeof tile.style !== "undefined") tile.style = TileSetStyle[tile.style];
+				if (typeof tile.style === "string") tile.style = TileSetStyle[tile.style];
 				if (typeof tile.validVersion !== "undefined")
 					tile.validVersion = tile.validVersion.map(version => {
 						if (typeof version.genericTile !== "undefined")
 							version.genericTile = version.genericTile.map(genericTile => {
-								if (typeof genericTile.tileType !== "undefined") genericTile.tileType = GenericTileType[genericTile.tileType];
+								if (typeof genericTile.tileType === "string") genericTile.tileType = GenericTileType[genericTile.tileType];
 								return genericTile;
 							});
 						return version;
 					});
-				if (typeof tile.scale !== "undefined") tile.scale = TileScale[tile.scale];
-				if (typeof tile.size !== "undefined") tile.size = TileSize[tile.size];
-				if (typeof tile.updateBehavior !== "undefined") tile.updateBehavior = TileSet_TileSetVersionUpdateBehavior[tile.updateBehavior];
-				if (typeof tile.checksumType !== "undefined") tile.checksumType = TileSet_TileSetChecksumType[tile.checksumType];
-				if (typeof tile.requestStyle !== "undefined") tile.requestStyle = TileSet_TileRequestStyle[tile.requestStyle];
+				if (typeof tile.scale === "string") tile.scale = TileScale[tile.scale];
+				if (typeof tile.size === "string") tile.size = TileSize[tile.size];
+				if (typeof tile.updateBehavior === "string") tile.updateBehavior = TileSet_TileSetVersionUpdateBehavior[tile.updateBehavior];
+				if (typeof tile.checksumType === "string") tile.checksumType = TileSet_TileSetChecksumType[tile.checksumType];
+				if (typeof tile.requestStyle === "string") tile.requestStyle = TileSet_TileRequestStyle[tile.requestStyle];
 				return tile;
 			});
 		if (typeof body.attribution !== "undefined")
 			body.attribution = body.attribution.map(attribution => {
 				if (typeof attribution.resource !== "undefined")
 					attribution.resource = attribution.resource.map(resource => {
-						if (typeof resource.resourceType !== "undefined") resource.resourceType = ResourceType[resource.resourceType];
+						if (typeof resource.resourceType === "string") resource.resourceType = ResourceType[resource.resourceType];
 						if (typeof resource.filter !== "undefined")
 							resource.filter = resource.filter.map(filter => {
-								if (typeof filter.scale !== "undefined") filter.scale = filter.scale.map(scale => ResourceFilterScale[scale]);
-								if (typeof filter.scenario !== "undefined") filter.scenario = filter.scenario.map(scenario => ResourceFilterScenario[scenario]);
+								if (typeof filter.scale !== "undefined") filter.scale = filter.scale.map(scale => typeof scale === "string" ? ResourceFilterScale[scale] : scale);
+								if (typeof filter.scenario !== "undefined") filter.scenario = filter.scenario.map(scenario => typeof scenario === "string" ? ResourceFilterScenario[scenario] : scenario);
 								return filter;
 							});
-						if (typeof resource.connectionType !== "undefined") resource.connectionType = ResourceDownloadConnectionType[resource.connectionType];
-						if (typeof resource.validationMethod !== "undefined") resource.validationMethod = Resource_ValidationMethod[resource.validationMethod];
-						if (typeof resource.updateMethod !== "undefined") resource.updateMethod = Resource_UpdateMethod[resource.updateMethod];
+						if (typeof resource.connectionType === "string") resource.connectionType = ResourceDownloadConnectionType[resource.connectionType];
+						if (typeof resource.validationMethod === "string") resource.validationMethod = Resource_ValidationMethod[resource.validationMethod];
+						if (typeof resource.updateMethod === "string") resource.updateMethod = Resource_UpdateMethod[resource.updateMethod];
 						return resource;
 					});
 				return attribution;
 			});
 		if (typeof body.resource !== "undefined")
 			body.resource = body.resource.map(resource => {
-				if (typeof resource.resourceType !== "undefined") resource.resourceType = ResourceType[resource.resourceType];
+				if (typeof resource.resourceType === "string") resource.resourceType = ResourceType[resource.resourceType];
 				if (typeof resource.filter !== "undefined")
 					resource.filter = resource.filter.map(filter => {
-						if (typeof filter.scale !== "undefined") filter.scale = filter.scale.map(scale => ResourceFilterScale[scale]);
-						if (typeof filter.scenario !== "undefined") filter.scenario = filter.scenario.map(scenario => ResourceFilterScenario[scenario]);
+						if (typeof filter.scale !== "undefined") filter.scale = filter.scale.map(scale => typeof scale === "string" ? ResourceFilterScale[scale] : scale);
+						if (typeof filter.scenario !== "undefined") filter.scenario = filter.scenario.map(scenario => typeof scenario === "string" ? ResourceFilterScenario[scenario] : scenario);
 						return filter;
 					});
-				if (typeof resource.connectionType !== "undefined") resource.connectionType = ResourceDownloadConnectionType[resource.connectionType];
-				if (typeof resource.validationMethod !== "undefined") resource.validationMethod = Resource_ValidationMethod[resource.validationMethod];
-				if (typeof resource.updateMethod !== "undefined") resource.updateMethod = Resource_UpdateMethod[resource.updateMethod];
+				if (typeof resource.connectionType === "string") resource.connectionType = ResourceDownloadConnectionType[resource.connectionType];
+				if (typeof resource.validationMethod === "string") resource.validationMethod = Resource_ValidationMethod[resource.validationMethod];
+				if (typeof resource.updateMethod === "string") resource.updateMethod = Resource_UpdateMethod[resource.updateMethod];
 				return resource;
 			});
 		Console.log("✅ GEOResourceManifestDownload.decode");

--- a/src/function/InternationalHybrid.mjs
+++ b/src/function/InternationalHybrid.mjs
@@ -1,0 +1,400 @@
+const INTERNATIONAL_3D_STYLES = new Set([
+	// iOS 27 uses the formerly reserved style 98 for the international
+	// satellite selector (observed as /tile?style=98). It must remain in the
+	// single international selector set for coordinate-based CN routing.
+	"UNUSED_98",
+	"SPUTNIK_METADATA",
+	"SPUTNIK_C3M",
+	"SPUTNIK_DSM",
+	"SPUTNIK_DSM_GLOBAL",
+	"SPUTNIK_VECTOR_BORDER",
+	"FLYOVER_C3M_MESH",
+	"FLYOVER_C3M_JPEG_TEXTURE",
+	"FLYOVER_C3M_ASTC_TEXTURE",
+	"FLYOVER_VISIBILITY",
+	"FLYOVER_SKYBOX",
+	"FLYOVER_NAVGRAPH",
+	"FLYOVER_METADATA",
+	"MUNIN_METADATA",
+	"VECTOR_SPR_MERCATOR",
+	"VECTOR_SPR_MODELS",
+	"VECTOR_SPR_MATERIALS",
+	"VECTOR_SPR_METADATA",
+	"SPR_ASSET_METADATA",
+	"VECTOR_SPR_POLAR",
+	"VECTOR_SPR_MODELS_OCCLUSION",
+]);
+
+// Mainland 3D is optional because duplicate capability styles are more
+// sensitive than ordinary 2D tiles on iOS 27. Keep Munin/Look Around and the
+// global border/polar selectors international-only even when this is enabled.
+const MAINLAND_3D_STYLES = new Set([
+	"SPUTNIK_METADATA",
+	"SPUTNIK_C3M",
+	"SPUTNIK_DSM",
+	"SPUTNIK_DSM_GLOBAL",
+	"FLYOVER_C3M_MESH",
+	"FLYOVER_C3M_JPEG_TEXTURE",
+	"FLYOVER_C3M_ASTC_TEXTURE",
+	"FLYOVER_VISIBILITY",
+	"FLYOVER_SKYBOX",
+	"FLYOVER_NAVGRAPH",
+	"FLYOVER_METADATA",
+	"VECTOR_SPR_MERCATOR",
+	"VECTOR_SPR_MODELS",
+	"VECTOR_SPR_MATERIALS",
+	"VECTOR_SPR_METADATA",
+	"SPR_ASSET_METADATA",
+	"VECTOR_SPR_MODELS_OCCLUSION",
+]);
+
+const MAINLAND_CORE_STYLES = new Set([
+	"VECTOR_STANDARD",
+	"VECTOR_BUILDINGS",
+	"VECTOR_POI",
+	"VECTOR_REALISTIC",
+	"VECTOR_VENUES",
+	"VECTOR_LAND_COVER",
+	"VECTOR_STREET_POI",
+	"VECTOR_STREET_LANDMARKS",
+	"VECTOR_POI_V2",
+	"VECTOR_BUILDINGS_V2",
+	"VECTOR_POI_V2_UPDATE",
+]);
+
+const MAINLAND_EXTENDED_STYLES = new Set([
+	...MAINLAND_CORE_STYLES,
+	"VECTOR_TRAFFIC_SEGMENTS_FOR_RASTER",
+	"VECTOR_TRAFFIC_INCIDENTS_FOR_RASTER",
+	"VECTOR_TRAFFIC_SEGMENTS_AND_INCIDENTS_FOR_RASTER",
+	"RASTER_STANDARD_BACKGROUND",
+	"RASTER_HYBRID",
+	"RASTER_SATELLITE",
+	"RASTER_TERRAIN",
+	"VECTOR_TRAFFIC",
+	"VECTOR_ROADS",
+	"RASTER_VEGETATION",
+	"VECTOR_TRAFFIC_SKELETON",
+	"RASTER_COASTLINE_MASK",
+	"RASTER_HILLSHADE",
+	"VECTOR_TRAFFIC_WITH_GREEN",
+	"VECTOR_TRAFFIC_STATIC",
+	"RASTER_COASTLINE_DROP_MASK",
+	"VECTOR_TRAFFIC_SKELETON_WITH_HISTORICAL",
+	"VECTOR_SPEED_PROFILES",
+	"RASTER_DOWN_SAMPLED",
+	"RASTER_COLOR_BALANCED",
+	"RASTER_SATELLITE_NIGHT",
+	"RASTER_SATELLITE_DIGITIZE",
+	"RASTER_HILLSHADE_PARKS",
+	"RASTER_STANDARD_BASE",
+	"RASTER_STANDARD_LABELS",
+	"RASTER_HYBRID_ROADS",
+	"RASTER_HYBRID_LABELS",
+	"RASTER_SATELLITE_ASTC",
+	"RASTER_HYBRID_ROADS_AND_LABELS",
+	"VECTOR_POLYGON_SELECTION",
+	"VECTOR_TRAFFIC_V2",
+	"VECTOR_TOPOGRAPHIC",
+	"VECTOR_CONTOURS",
+]);
+
+const MAINLAND_AT_Z8 = [
+	[214, 82, 216, 82], [213, 83, 217, 83], [213, 84, 218, 84], [213, 85, 218, 85],
+	[212, 86, 218, 86], [189, 87, 190, 87], [210, 87, 220, 87], [188, 88, 191, 88],
+	[210, 88, 223, 88], [188, 89, 192, 89], [210, 89, 223, 89], [186, 90, 192, 90],
+	[210, 90, 223, 90], [186, 91, 192, 91], [209, 91, 222, 91], [184, 92, 195, 92],
+	[207, 92, 221, 92], [185, 93, 196, 93], [206, 93, 221, 93], [182, 94, 219, 95],
+	[180, 96, 217, 96], [180, 97, 216, 97], [180, 98, 214, 98], [180, 99, 215, 99],
+	[182, 100, 214, 100], [183, 101, 213, 101], [184, 102, 214, 102], [183, 103, 214, 103],
+	[184, 104, 215, 104], [185, 105, 215, 105], [187, 106, 215, 106], [189, 107, 193, 107],
+	[197, 107, 213, 107], [198, 108, 213, 108], [197, 109, 213, 109], [197, 110, 213, 110],
+	[198, 111, 213, 111], [204, 112, 209, 112], [205, 113, 207, 113], [205, 114, 206, 114],
+	[205, 115, 207, 115],
+];
+
+const clone = value => {
+	if (typeof structuredClone === "function") return structuredClone(value);
+	return JSON.parse(JSON.stringify(value));
+};
+
+const endpoint = value => String(value?.url ?? value?.baseURL ?? value ?? "");
+const isMainlandEndpoint = value => /(?:-cn-ssl\.ls\.apple\.(?:com|cn)|\.is\.autonavi\.com)(?:[/:]|$)/i.test(endpoint(value));
+
+const mainlandRegions = (minZ, maxZ) => {
+	const factor = 2 ** (minZ - 8);
+	return MAINLAND_AT_Z8.map(([minX, minY, maxX, maxY]) => ({
+		minX: minX * factor,
+		minY: minY * factor,
+		maxX: (maxX + 1) * factor - 1,
+		maxY: (maxY + 1) * factor - 1,
+		minZ,
+		maxZ,
+	}));
+};
+
+const copyKeys = (target, source, keys) => {
+	for (const key of keys) {
+		if (typeof source?.[key] !== "undefined") target[key] = clone(source[key]);
+	}
+};
+
+const saveRouteConfig = (caches, enabled) => {
+	if (!enabled || !globalThis.$persistentStore?.write) return;
+	const routedStyles = new Set([
+		"RASTER_SATELLITE",
+		"RASTER_SATELLITE_NIGHT",
+		"RASTER_SATELLITE_DIGITIZE",
+		"RASTER_SATELLITE_ASTC",
+		...MAINLAND_3D_STYLES,
+	]);
+	const routes = [];
+	for (const internationalTile of caches.XX?.tileSet ?? []) {
+		if (!routedStyles.has(internationalTile?.style) || !internationalTile?.baseURL) continue;
+		const mainlandTile = caches.CN?.tileSet?.find(tile =>
+			tile?.style === internationalTile.style &&
+			tile?.scale === internationalTile.scale &&
+			tile?.size === internationalTile.size
+		) ?? caches.CN?.tileSet?.find(tile => tile?.style === internationalTile.style);
+		if (!mainlandTile?.baseURL) continue;
+		const internationalVersions = internationalTile.validVersion ?? [];
+		const mainlandVersions = mainlandTile.validVersion ?? [];
+		const versionMap = {};
+		for (let index = 0; index < internationalVersions.length; index++) {
+			const from = internationalVersions[index]?.identifier;
+			const to = mainlandVersions[index]?.identifier ?? mainlandVersions[0]?.identifier;
+			if (typeof from !== "undefined" && typeof to !== "undefined") versionMap[String(from)] = String(to);
+		}
+		routes.push({
+			style: internationalTile.style,
+			fromStyle: internationalTile.style,
+			toStyle: mainlandTile.style,
+			scale: internationalTile.scale,
+			size: internationalTile.size,
+			internationalBaseURL: internationalTile.baseURL,
+			mainlandBaseURL: mainlandTile.baseURL,
+			versionMap,
+		});
+	}
+	// Confirmed on iOS 27: the international satellite selector is style 98,
+	// while the equivalent AutoNavi/CN selector remains RASTER_SATELLITE (7).
+	// The current protobuf schema still names 98 UNUSED_98, so it cannot be
+	// paired by the legacy same-name loop above.
+	const internationalSatellite = caches.XX?.tileSet?.find(tile => tile?.style === "UNUSED_98");
+	const mainlandSatellite = caches.CN?.tileSet?.find(tile =>
+		tile?.style === "RASTER_SATELLITE" &&
+		tile?.scale === internationalSatellite?.scale &&
+		tile?.size === internationalSatellite?.size
+	) ?? caches.CN?.tileSet?.find(tile => tile?.style === "RASTER_SATELLITE");
+	if (internationalSatellite?.baseURL && mainlandSatellite?.baseURL) {
+		const fromVersions = internationalSatellite.validVersion ?? [];
+		const toVersions = mainlandSatellite.validVersion ?? [];
+		const versionMap = {};
+		for (let index = 0; index < fromVersions.length; index++) {
+			const from = fromVersions[index]?.identifier;
+			const to = toVersions[index]?.identifier ?? toVersions[0]?.identifier;
+			if (typeof from !== "undefined" && typeof to !== "undefined") versionMap[String(from)] = String(to);
+		}
+		// Keep the observed mapping as a compatibility fallback if manifest
+		// version ordering changes or omits one side during cache warm-up.
+		versionMap["226"] ??= "68";
+		routes.push({
+			style: "UNUSED_98",
+			fromStyle: "UNUSED_98",
+			toStyle: "RASTER_SATELLITE",
+			fromStyleValue: "98",
+			toStyleValue: "7",
+			scale: internationalSatellite.scale,
+			size: internationalSatellite.size,
+			internationalBaseURL: internationalSatellite.baseURL,
+			mainlandBaseURL: mainlandSatellite.baseURL,
+			versionMap,
+			targetQuery: {
+				size: String(mainlandSatellite.size ?? 1),
+				scale: String(mainlandSatellite.scale ?? 2),
+				vertical_datum: "wgs84",
+			},
+			removeQuery: ["region", "h"],
+		});
+	}
+	globalThis.$persistentStore.write(JSON.stringify({ updatedAt: Date.now(), routes }), "iRingo.Maps.HybridSatelliteRoute.v3");
+};
+
+/**
+ * Keep the international manifest authoritative while adding mainland-only
+ * rendering and service data. Inspired by the supplied Loon hybrid fix, but
+ * deliberately keeps service selection configurable for iOS 27.
+ */
+export default function applyInternationalHybrid(body, caches, settings = {}) {
+	const enabled = String(settings?.Hybrid?.Enabled ?? "false").toLowerCase() !== "false";
+	if (!enabled || !body || !Array.isArray(body.tileSet) || !Array.isArray(caches?.CN?.tileSet)) return body;
+
+	const layerMode = String(settings?.Hybrid?.MainlandLayers ?? "EXTENDED").toUpperCase();
+	const mainlandStyles = new Set(layerMode === "CORE" ? MAINLAND_CORE_STYLES : MAINLAND_EXTENDED_STYLES);
+	const mainland3DMode = String(settings?.Hybrid?.Mainland3D ?? "DISABLED").toUpperCase();
+	const coordinateRouteEnabled = mainland3DMode === "ROUTE";
+	if (coordinateRouteEnabled) {
+		// Duplicate CN/global imagery styles are sticky on iOS 27. Leave one
+		// international selector and let the request route choose CN by tile
+		// coordinate, so switching directly from China to an overseas city works.
+		for (const style of [
+			"RASTER_SATELLITE",
+			"RASTER_SATELLITE_NIGHT",
+			"RASTER_SATELLITE_DIGITIZE",
+			"RASTER_SATELLITE_ASTC",
+		]) mainlandStyles.delete(style);
+		saveRouteConfig(caches, true);
+	}
+	const international3DTiles = (caches.XX?.tileSet ?? [])
+		.filter(tile => INTERNATIONAL_3D_STYLES.has(tile?.style))
+		.map(sourceTile => {
+			const tile = clone(sourceTile);
+			if (tile.style === "UNUSED_98" && Array.isArray(tile.validVersion)) {
+				// The iOS 27 international satellite selector normally has no CN
+				// coverage, so Maps never emits a mainland request to the route.
+				// Add the mainland tile regions to this single selector; the request
+				// router then converts only those coordinates to AutoNavi. Keep the
+				// original international coverage for every other country.
+				tile.countryRegionWhitelist = [];
+				tile.validVersion = tile.validVersion.map(version => ({
+					...version,
+					availableTiles: [
+						...(version.availableTiles ?? []),
+						...mainlandRegions(8, Math.max(22, version.availableTiles?.reduce((max, region) => Math.max(max, region.maxZ), 0) || 0)),
+					],
+				}));
+			}
+			return tile;
+		});
+	const international3DKeys = new Set(
+		[...INTERNATIONAL_3D_STYLES].map(style => style),
+	);
+
+	// Remove old mainland copies before inserting exactly one region-limited
+	// replacement. Roads/network/transit/Munin capability selectors remain Apple
+	// international; this avoids double labels and broken Look Around selection.
+	body.tileSet = body.tileSet.filter(tile =>
+		!international3DKeys.has(tile?.style) &&
+		!(mainlandStyles.has(tile?.style) && isMainlandEndpoint(tile?.baseURL))
+	);
+	for (const sourceTile of international3DTiles) {
+		const exists = body.tileSet.some(tile =>
+			tile?.style === sourceTile.style &&
+			tile?.scale === sourceTile.scale &&
+			tile?.size === sourceTile.size &&
+			tile?.dataSet === sourceTile.dataSet
+		);
+		if (!exists) body.tileSet.push(sourceTile);
+	}
+
+	const mainland3DEnabled = mainland3DMode === "ENABLED" || mainland3DMode === "NATIVE";
+	const china3DTiles = [];
+	if (mainland3DEnabled) {
+		for (const sourceTile of caches.CN.tileSet) {
+			if (!MAINLAND_3D_STYLES.has(sourceTile?.style)) continue;
+			const tile = clone(sourceTile);
+			tile.countryRegionWhitelist = [{ countryCode: "CN", region: "" }];
+			// Preserve Apple's original CN 3D availability polygons. Unlike 2D,
+			// expanding sparse model coverage to all mainland tiles would create
+			// empty meshes and could hide the international fallback.
+			if (Array.isArray(tile.validVersion) && tile.validVersion.length) china3DTiles.push(tile);
+		}
+	}
+
+	const chinaTiles = [];
+	for (const sourceTile of caches.CN.tileSet) {
+		if (!mainlandStyles.has(sourceTile?.style)) continue;
+		const tile = clone(sourceTile);
+		// Keep the source dataset identity where present; iOS 27 uses it when
+		// selecting China road/label/satellite variants. Coverage is restricted by
+		// availableTiles, and an explicit CN whitelist adds a second boundary.
+		tile.countryRegionWhitelist = [{ countryCode: "CN", region: "" }];
+		tile.validVersion = (tile.validVersion || []).map(version => {
+			const sourceRegions = version.availableTiles || [];
+			const sourceMinZ = Math.min(...sourceRegions.map(region => region.minZ));
+			const sourceMaxZ = Math.max(...sourceRegions.map(region => region.maxZ));
+			const minZ = Math.max(8, sourceMinZ);
+			return {
+				...version,
+				availableTiles: Number.isFinite(sourceMaxZ) && sourceMaxZ >= minZ ? mainlandRegions(minZ, sourceMaxZ) : [],
+				timeToLiveSeconds: Math.min(version.timeToLiveSeconds || 3600, 3600),
+			};
+		}).filter(version => version.availableTiles.length);
+		if (tile.validVersion.length) chinaTiles.push(tile);
+	}
+	// CN entries precede the international fallback only inside this optional
+	// profile. Their original coverage plus CN whitelist keeps them regional.
+	body.tileSet = [...china3DTiles, ...chinaTiles, ...body.tileSet];
+
+	// Start with the Apple international endpoint set. Then selectively restore
+	// mainland services instead of allowing a broad object merge to leak CN-only
+	// capability endpoints into Flyover, Look Around or global coverage.
+	const internationalUrlInfo = caches.XX?.urlInfoSet?.[0];
+	const mainlandUrlInfo = caches.CN?.urlInfoSet?.[0];
+	if (Array.isArray(body.urlInfoSet) && internationalUrlInfo && mainlandUrlInfo) {
+		const hybridUrlInfo = clone(internationalUrlInfo);
+		// CN_POI is the stable default for the hybrid profile: restore mainland
+		// AutoNavi place/POI and reverse-geocoding data while keeping Apple
+		// navigation unless the module explicitly selects another mode.
+		const mode = String(settings?.Hybrid?.ServiceMode ?? "CN_POI").toUpperCase();
+		const reverseGeocodingKeys = [
+			"batchReverseGeocoderURL",
+			"backgroundRevGeoURL",
+			"batchReverseGeocoderPlaceRequestURL",
+			"reverseGeocoderVersionsURL",
+		];
+		const placeKeys = [
+			"dispatcherURL",
+			"backgroundDispatcherURL",
+			"bluePOIDispatcherURL",
+			"spatialLookupURL",
+			"alternateResourcesURL",
+			"addressCorrectionInitURL",
+			"addressCorrectionUpdateURL",
+		];
+		const navigationKeys = [
+			"directionsURL",
+			"etaURL",
+			"simpleETAURL",
+			"proactiveRoutingURL",
+			"realtimeTrafficProbeURL",
+			"batchTrafficProbeURL",
+		];
+		copyKeys(hybridUrlInfo, mainlandUrlInfo, reverseGeocodingKeys);
+		if (mode === "CN_POI" || mode === "CN_FULL") copyKeys(hybridUrlInfo, mainlandUrlInfo, placeKeys);
+		if (mode === "CN_FULL") copyKeys(hybridUrlInfo, mainlandUrlInfo, navigationKeys);
+		if (settings?.UrlInfoSet?.LocationShift === "AutoNavi") {
+			copyKeys(hybridUrlInfo, mainlandUrlInfo, [
+				"polyLocationShiftURL",
+				"locationShiftURL",
+				"locationShiftEnabledRegion",
+				"locationShiftVersion",
+			]);
+		}
+		body.urlInfoSet[0] = hybridUrlInfo;
+	}
+
+	if (Array.isArray(body.attribution)) {
+		body.attribution = body.attribution.map(item => {
+			if (item?.name !== "AutoNavi") return item;
+			const attribution = clone(item);
+			attribution.resource = (attribution.resource || []).filter(resource =>
+				resource?.resourceType !== 6 && resource?.resourceType !== "ATTRIBUTION_LOGO"
+			);
+			return attribution;
+		});
+	}
+
+	const leakedCriticalTile = body.tileSet.find(tile =>
+		INTERNATIONAL_3D_STYLES.has(tile?.style) &&
+		isMainlandEndpoint(tile?.baseURL) &&
+		(!mainland3DEnabled || !MAINLAND_3D_STYLES.has(tile?.style))
+	);
+	const internationalMunin = body.tileSet.find(tile => tile?.style === "MUNIN_METADATA" && !isMainlandEndpoint(tile?.baseURL));
+	const mainlandMunin = body.tileSet.find(tile => tile?.style === "MUNIN_METADATA" && isMainlandEndpoint(tile?.baseURL));
+	if (leakedCriticalTile) console.log(`[iRingo Hybrid] warning: unexpected mainland 3D style remains: ${leakedCriticalTile.style}`);
+	if (!internationalMunin) console.log("[iRingo Hybrid] warning: international Munin metadata was not found");
+	if (mainlandMunin) console.log("[iRingo Hybrid] warning: mainland Munin metadata must remain disabled");
+	console.log(`[iRingo Hybrid] injected ${chinaTiles.length} mainland-only 2D and ${china3DTiles.length} original-coverage 3D tile sets; service mode ${settings?.Hybrid?.ServiceMode ?? "CN_POI"}`);
+	return body;
+}

--- a/src/function/database.mjs
+++ b/src/function/database.mjs
@@ -9,6 +9,12 @@ export default {
 	},
 	Maps: {
 		Settings: {
+			Hybrid: {
+				Enabled: false,
+				MainlandLayers: "EXTENDED",
+				Mainland3D: "DISABLED",
+				ServiceMode: "CN_POI",
+			},
 			UrlInfoSet: {
 				Dispatcher: "AutoNavi",
 				Directions: "AutoNavi",

--- a/src/process/Request.mjs
+++ b/src/process/Request.mjs
@@ -99,6 +99,7 @@ export async function Request($request, KV) {
                     }
                     break;
                 case "gspe35-ssl.ls.apple.com":
+                case "gspe35-ssl.ls.apple.cn":
                     switch (url.pathname) {
                         case "/config/announcements":
                             switch (Settings?.Config?.Announcements?.Environment ?? Settings?.Config?.Announcements?.["Environment:"]?.default ?? Settings?.Config?.Announcements?.["Environment:"]) {
@@ -121,9 +122,14 @@ export async function Request($request, KV) {
                                             url.searchParams.set("country_code", Caches.pep.gcc);
                                             break;
                                         case "CN":
-                                        case undefined:
-                                            url.searchParams.set("country_code", "CN");
+                                        case undefined: {
+                                            // PEP is not guaranteed to be available on iOS 27.
+                                            // Infer a safe fallback from the user's language
+                                            // instead of pinning every AUTO request to CN.
+                                            const language = $request.headers?.["Accept-Language"] ?? $request.headers?.["accept-language"] ?? "";
+                                            url.searchParams.set("country_code", !language || /^zh(?:-Hans)?(?:-CN)?/i.test(language) ? "CN" : "US");
                                             break;
+                                        }
                                     }
                                     break;
                                 default:

--- a/src/process/Response.mjs
+++ b/src/process/Response.mjs
@@ -4,6 +4,7 @@ import database from "../function/database.mjs";
 import setENV from "../function/setENV.mjs";
 import GEOResourceManifest from "../class/GEOResourceManifest.mjs";
 import GEOResourceManifestDownload from "../class/GEOResourceManifestDownload.mjs";
+import applyInternationalHybrid from "../function/InternationalHybrid.mjs";
 /***************** Processing *****************/
 export async function Response($request, $response, KV) {
     // 解构URL
@@ -111,7 +112,8 @@ export async function Response($request, $response, KV) {
                 case "application/vnd.google.protobuf":
                 case "application/octet-stream":
                     switch (url.hostname) {
-                        case "gspe35-ssl.ls.apple.com":
+                case "gspe35-ssl.ls.apple.com":
+                case "gspe35-ssl.ls.apple.cn":
                             switch (url.pathname) {
                                 case "/config/announcements":
                                     break;
@@ -162,6 +164,7 @@ export async function Response($request, $response, KV) {
                                     body.urlInfoSet = GEOResourceManifest.urlInfoSets(body.urlInfoSet, caches, Settings, CountryCode);
                                     body.muninBucket = GEOResourceManifest.muninBuckets(body.muninBucket, caches, Settings);
                                     body.displayString = GEOResourceManifest.displayStrings(body.displayString, caches, CountryCode);
+                                    body = applyInternationalHybrid(body, caches, Settings);
                                     body.tileGroup = GEOResourceManifest.tileGroups(body.tileGroup, body.tileSet, body.attribution, body.resource);
                                     Console.debug(`releaseInfo: ${body.releaseInfo}`);
                                     rawBody = GEOResourceManifestDownload.encode(body);

--- a/src/satellite-route.js
+++ b/src/satellite-route.js
@@ -1,0 +1,34 @@
+/* iOS 27 mainland satellite route: style 98/226 -> CN style 7/68. */
+(() => {
+	const request = globalThis.$request;
+	if (!request?.url) return $done({});
+	const url = new URL(request.url);
+	const style = url.searchParams.get("style") ?? url.searchParams.get("tile_style");
+	if (url.hostname !== "gspe11-ssl.ls.apple.com" || url.pathname !== "/tile" || style !== "98") return $done({});
+	const number = key => Number(url.searchParams.get(key));
+	const x = number("x"), y = number("y"), z = number("z");
+	if (![x, y, z].every(Number.isInteger) || z < 1 || z > 30) return $done({});
+	const factor = z >= 8 ? 2 ** (z - 8) : 1 / 2 ** (8 - z);
+	const x8 = Math.floor(x / factor), y8 = Math.floor(y / factor);
+	const mainland = [
+		[214,82,216,82],[213,83,217,83],[213,84,218,84],[213,85,218,85],[212,86,218,86],
+		[189,87,190,87],[210,87,220,87],[188,88,191,88],[210,88,223,88],[188,89,192,89],
+		[210,89,223,89],[186,90,192,90],[210,90,223,90],[186,91,192,91],[209,91,222,91],
+		[184,92,195,92],[207,92,221,92],[185,93,196,93],[206,93,221,93],[182,94,219,95],
+		[180,96,217,96],[180,97,216,97],[180,98,214,98],[180,99,215,99],[182,100,214,100],
+		[183,101,213,101],[184,102,214,102],[183,103,214,103],[184,104,215,104],[185,105,215,105],
+		[187,106,215,106],[189,107,193,107],[197,107,213,107],[198,108,213,108],[197,109,213,109],
+		[197,110,213,110],[198,111,213,111],[204,112,209,112],[205,113,207,113],[205,114,206,114],[205,115,207,115],
+	];
+	if (!mainland.some(([minX,minY,maxX,maxY]) => x8 >= minX && x8 <= maxX && y8 >= minY && y8 <= maxY)) return $done({});
+	url.hostname = "gspe11-2-cn-ssl.ls.apple.com";
+	url.pathname = "/2/tiles";
+	url.searchParams.set("style", "7");
+	url.searchParams.set("v", "68");
+	url.searchParams.set("size", "1");
+	url.searchParams.set("scale", "2");
+	url.searchParams.set("vertical_datum", "wgs84");
+	url.searchParams.delete("region");
+	url.searchParams.delete("h");
+	$done({ url: url.toString() });
+})();

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,4 +1,14 @@
 export interface Settings {
+    Hybrid?: {
+        /** Enable iOS 27 mainland/international selective manifest merging. */
+        Enabled?: boolean;
+        /** Mainland two-dimensional layer profile. */
+        MainlandLayers?: 'CORE' | 'EXTENDED';
+        /** Mainland 3D behavior. ROUTE keeps one international selector. */
+        Mainland3D?: 'DISABLED' | 'ENABLED' | 'NATIVE' | 'ROUTE';
+        /** Mainland place/navigation service scope. */
+        ServiceMode?: 'APPLE' | 'CN_POI' | 'CN_FULL';
+    };
     GeoManifest?: {
     Dynamic?: {
             Config?: {


### PR DESCRIPTION
## 概述

为 iOS 27 增加可选的中国大陆/国际地图混合模式：中国大陆保留标准地图、道路、地点、POI 与坐标修正，中国大陆以外保留 Apple 国际卫星、3D、Flyover、地球与 Look Around 资源。

## 主要更改

- 新增 `Hybrid.Enabled`、`Hybrid.MainlandLayers`、`Hybrid.Mainland3D` 和 `Hybrid.ServiceMode` 配置；
- 以国际版 `Geo Manifest` 为主体，仅注入限制在中国大陆范围内的二维地图图层；
- 识别 iOS 27 实机观察到的国际卫星选择器 `style=98`，当前协议枚举名为 `UNUSED_98`；
- 新增独立构建的卫星请求路由：将中国大陆坐标下已确认的 `style=98/v=226` 请求转换为 CN `style=7/v=68`，国外请求保持不变；
- 增加 `gspe35-ssl.ls.apple.cn` 清单请求与响应支持；
- 修复 `Geo Manifest` 中枚举值已经是数字时再次反向转换导致的 `invalid int 32: string`；
- 增加中国大陆与东京卫星请求的路由回归测试。

## 默认行为与兼容性

混合功能默认关闭：

```text
Hybrid.Enabled=false
```

因此现有 Maps 配置和原项目默认行为不会发生变化。用户明确启用后，才会执行中国/国际资源选择性合并。

`Hybrid.Mainland3D=ROUTE` 适用于能够同时安装独立 HTTP 请求脚本的客户端。该模式只保留一套国际卫星选择器，再根据瓦片坐标决定是否切换到 CN 端点，用于避免 iOS 27 在卫星视图中锁定当前数据源。

## 验证

- 已对新增及修改的 JavaScript 源文件执行语法检查；
- 中国大陆坐标请求会转换为 CN 主机、路径、样式与版本；
- 东京坐标请求保持原国际 URL 不变；
- 实现来源于 `patrickyanxxxxx/Maps` 中已实机验证的 `v6.2.1` 稳定配置。

## PR 范围

本 PR 只包含上游可维护的核心源码、配置项、独立路由入口和回归测试，不包含：

- Fork 专用发行模块；
- 历史实验版本与归档目录；
- 卫星诊断附件；
- 个人 README 与发布说明；
- 预先生成的 request/response bundle。

## 已知限制

- 当前仅转换实机确认的 iOS 27 `style=98/v=226` 卫星请求；
- 不猜测转换未知的夜景、3D 模型、网格或材质样式；
- 3D、Flyover 与 Look Around 的实际城市覆盖仍由 Apple 服务端决定。
